### PR TITLE
feat(commits): list commits since a commitish

### DIFF
--- a/commits.ts
+++ b/commits.ts
@@ -1,10 +1,5 @@
 import { requestData } from './utils/graphql.js';
 
-function gql(strs: TemplateStringsArray, ...keys: any[]) {
-  const l = strs.length - 1;
-  return strs.slice(0, l).reduce((p, s, i) => p + s + keys[i], '') + strs[l];
-}
-
 export interface Commit {
   messageHeadline: string;
   abbreviatedOid: string;
@@ -27,10 +22,10 @@ interface HistoryResponse {
 }
 
 /**
- * Get commits since a commitish
- * @param org Repository owner/organization
- * @param repo Repository name
- * @param ref get commits from this commitish, inclusive
+ * Get commits since (inclusive) given commitish
+ * @param org repository owner/organization
+ * @param repo repository name
+ * @param ref commitish
  * @example
  * ```
  * for await (const commit of getCommits('w3c', 'respec', 'HEAD~5')) {
@@ -49,7 +44,7 @@ export async function* getCommits(org: string, repo: string, ref: string) {
 }
 
 async function getSinceDate(org: string, repo: string, ref: string) {
-  const query = gql`
+  const query = `
     query($org: String!, $repo: String!, $ref: String!) {
       repository(owner: $org, name: $repo) {
         object(expression: $ref) {
@@ -79,7 +74,7 @@ async function getCommitsSince(
   since: string,
   cursor?: string,
 ) {
-  const query = gql`
+  const query = `
     query(
       $org: String!
       $repo: String!

--- a/commits.ts
+++ b/commits.ts
@@ -1,0 +1,123 @@
+import { requestData } from './utils/graphql.js';
+
+function gql(strs: TemplateStringsArray, ...keys: any[]) {
+  const l = strs.length - 1;
+  return strs.slice(0, l).reduce((p, s, i) => p + s + keys[i], '') + strs[l];
+}
+
+export interface Commit {
+  messageHeadline: string;
+  abbreviatedOid: string;
+  committedDate: string;
+  author: { user: { login: string; name: string } };
+}
+
+interface HistoryResponse {
+  repository: {
+    object: {
+      history: {
+        nodes: Commit[];
+        pageInfo: {
+          endCursor: string;
+          hasNextPage: boolean;
+        };
+      };
+    };
+  };
+}
+
+/**
+ * Get commits since a commitish
+ * @param org Repository owner/organization
+ * @param repo Repository name
+ * @param ref get commits from this commitish, inclusive
+ * @example
+ * ```
+ * for await (const commit of getCommits('w3c', 'respec', 'HEAD~5')) {
+ *   console.log(commit);
+ * }
+ * ```
+ */
+export async function* getCommits(org: string, repo: string, ref: string) {
+  const since = await getSinceDate(org, repo, ref);
+  let cursor: string | undefined;
+  do {
+    const data = await getCommitsSince(org, repo, since, cursor);
+    yield* data.commits;
+    cursor = data.cursor;
+  } while (!!cursor);
+}
+
+async function getSinceDate(org: string, repo: string, ref: string) {
+  const query = gql`
+    query($org: String!, $repo: String!, $ref: String!) {
+      repository(owner: $org, name: $repo) {
+        object(expression: $ref) {
+          ... on Commit {
+            history(first: 1) {
+              nodes {
+                committedDate
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await requestData(query, { org, repo, ref });
+  const repository: HistoryResponse['repository'] | null = data.repository;
+  if (repository === null) {
+    throw new Error('Cannot query `since` date using given org/repo@ref');
+  }
+  return repository.object.history.nodes[0].committedDate;
+}
+
+async function getCommitsSince(
+  org: string,
+  repo: string,
+  since: string,
+  cursor?: string,
+) {
+  const query = gql`
+    query(
+      $org: String!
+      $repo: String!
+      $since: GitTimestamp!
+      $cursor: String
+    ) {
+      repository(owner: $org, name: $repo) {
+        object(expression: "HEAD") {
+          ... on Commit {
+            history(since: $since, after: $cursor) {
+              nodes {
+                messageHeadline
+                abbreviatedOid
+                committedDate
+                author {
+                  user {
+                    login
+                    name
+                  }
+                }
+              }
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await requestData(query, { org, repo, since, cursor });
+
+  const { repository }: HistoryResponse = data;
+  const { nodes, pageInfo } = repository.object.history;
+  return {
+    commits: nodes,
+    cursor: pageInfo.hasNextPage ? pageInfo.endCursor : undefined,
+  };
+}

--- a/commits.ts
+++ b/commits.ts
@@ -22,7 +22,7 @@ interface HistoryResponse {
 }
 
 /**
- * Get commits since (inclusive) given commitish
+ * Get commits since given commitish
  * @param org repository owner/organization
  * @param repo repository name
  * @param ref commitish
@@ -110,9 +110,11 @@ async function getCommitsSince(
   const data = await requestData(query, { org, repo, since, cursor });
 
   const { repository }: HistoryResponse = data;
-  const { nodes, pageInfo } = repository.object.history;
+  const { nodes: commits, pageInfo } = repository.object.history;
+  // skip the commit referencing "ref" (on last page)
+  if (!pageInfo.hasNextPage) commits.pop();
   return {
-    commits: nodes,
+    commits,
     cursor: pageInfo.hasNextPage ? pageInfo.endCursor : undefined,
   };
 }


### PR DESCRIPTION
For https://github.com/w3c/respec/issues/1724

The commits are listed in same order as regular `git log`.

**How the caching works?** Without the cache, we get the `since` (date) for given commitish.
After fetching once, we set the `since` to the date of current `HEAD`. With cache, we start the search from the new `since` date, instead of from `ref`'s.

Caching benefits (fetching last 504 commits from a repository):
``` bash
➜  node commits.js
Failed to load cache: gh/commits.
# timestamp   # of records fetched
1570788384931 100
1570788386215 100
1570788387373 100
1570788388495 100
1570788389544 100
1570788390002 4

➜  node commits.js
1570788394641 504
1570788395097 0
```